### PR TITLE
toCSV() option documentation issue

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -403,7 +403,7 @@ string.js - Copyright (C) 2012-2013, JP Richardson <jprichardson@gmail.com>
     },
 
     toCSV: function() {
-      var delim = ',', qualifier = '"', escapeChar = '\\', encloseNumbers = true, keys = false;
+      var delim = ',', qualifier = '"', escape = '\\', encloseNumbers = true, keys = false;
       var dataArray = [];
 
       function hasVal(it) {
@@ -415,7 +415,7 @@ string.js - Copyright (C) 2012-2013, JP Richardson <jprichardson@gmail.com>
         delim = arguments[0].separator || delim;
         qualifier = arguments[0].qualifier || qualifier;
         encloseNumbers = !!arguments[0].encloseNumbers;
-        escapeChar = arguments[0].escapeChar || escapeChar;
+        escape = arguments[0].escape || escape;
         keys = !!arguments[0].keys;
       } else if (typeof arguments[0] === 'string') {
         delim = arguments[0];
@@ -438,7 +438,7 @@ string.js - Copyright (C) 2012-2013, JP Richardson <jprichardson@gmail.com>
               dataArray.push(this.orig[key]);
       }
 
-      var rep = escapeChar + qualifier;
+      var rep = escape + qualifier;
       var buildString = [];
       for (var i = 0; i < dataArray.length; ++i) {
         var shouldQualify = hasVal(qualifier)

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -487,6 +487,7 @@
         EQ (S({firstName: 'JP', lastName: 'Richardson'}).toCSV({keys: true}).s, '"firstName","lastName"');
         EQ (S({firstName: 'JP', lastName: 'Richardson'}).toCSV().s, '"JP","Richardson"');
         EQ (S(['a', null, undefined, 'c']).toCSV().s, '"a","","","c"');
+        EQ (S(['my "foo" bar', 'barf']).toCSV({delimiter: ';', qualifier: '"', escape: '"'}).s, '"my ""foo"" bar";"barf"');
       })
     })
 


### PR DESCRIPTION
The configurable option "Escape character" is documented as "escape" but was implemented as "escapeChar"
