### PR TITLE
added lines() function.

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -201,6 +201,10 @@ string.js - Copyright (C) 2012-2013, JP Richardson <jprichardson@gmail.com>
         return this.right(-N);
       }
     },
+    
+    lines: function() { //convert windows newlines to unix newlines then convert to an Array of lines
+      return this.replaceAll('\r\n', '\n').s.split('\n');
+    },
 
     pad: function(len, ch) { //https://github.com/component/pad
       ch = ch || ' ';


### PR DESCRIPTION
The basic functionality of the **lines()** function was useful. A cross platform method that would return an Array of lines. Unfortunately the previous method had the side effect of stripping unnecessary white space. My new method simply converts "Windows Style" (\r\n) lines to "Unix Style" (\n) lines. Then it just has to do split('\n') and now you have a classy cross platform **lines()** function.

**No white space was harmed in the making of this pull request.**
