### PR TITLE
Added replaceAt() method

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -322,6 +322,11 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
       return new this.constructor(s);
     },
 
+    replaceAt: function(i, r) { // http://stackoverflow.com/a/1431113/859328
+      var s = this.s.substr(0, i) + r + this.s.substr(i+r.length);
+      return new this.constructor(s);
+    },
+
     right: function(N) {
       if (N >= 0) {
         var s = this.s.substr(this.s.length - N, N);

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -408,6 +408,14 @@
       })
     })
 
+    describe('- replaceAt(index, replacement)', function() {
+      it('should return the new string with the character at the given index replaced with the replacment string', function() {
+        T (S('Replaceme125').replaceAt(11, '3').s === 'Replaceme123');
+        T (S('I juSt did').replaceAt(4, 's').s === 'I just did');
+        T (S('-£1024').replaceAt(0, '+').s === '+£1024');
+      })
+    })
+
     describe('+ restorePrototype()', function() {
       it('should restore the original String prototype', function() {
         T (typeof ' hi'.endsWith === 'undefined');


### PR DESCRIPTION
Replaces the character at the given index with the replacement.

**Example:**
```javascript
var string = "abc_123";
var output = S(string).replaceAt(3, ":"); // abc:123
```