### PR TITLE
Do not check for uppercase chars in regex

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -196,11 +196,11 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
     },
 
     isAlpha: function() {
-      return !/[^a-z\xC0-\xFF]/.test(this.s.toLowerCase());
+      return !/[^a-z\xDF-\xFF]/.test(this.s.toLowerCase());
     },
 
     isAlphaNumeric: function() {
-      return !/[^0-9a-z\xC0-\xFF]/.test(this.s.toLowerCase());
+      return !/[^0-9a-z\xDF-\xFF]/.test(this.s.toLowerCase());
     },
 
     isEmpty: function() {


### PR DESCRIPTION
Characters from \xC0 to  \xDE are upperCase.
Remove those chars from isAlpha and isAlphaNumeric regex.
No need to check because the string is already lower case.
