### PR TITLE
remove leading and trailing spaces before interpolating key

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -409,7 +409,7 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
       var matches = s.match(r) || [];
 
       matches.forEach(function(match) {
-        var key = match.substring(opening.length, match.length - closing.length);//chop {{ and }}
+        var key = match.substring(opening.length, match.length - closing.length).trim();//chop {{ and }}
         if (typeof values[key] != 'undefined')
           s = s.replace(match, values[key]);
       });

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -486,9 +486,12 @@
     describe('- template(values, [open], [close])', function() {
       it('should return the string replaced with template values', function() {
         var str = "Hello {{name}}! How are you doing during the year of {{date-year}}?"
-        var values = {name: 'JP', 'date-year': 2013}
+        var values = {greet: 'Hello', name: 'JP', 'date-year': 2013}
         EQ (S(str).template(values).s, 'Hello JP! How are you doing during the year of 2013?')
 
+        var str = "{{greet }} {{ name}}! How are you doing during the year of {{  date-year }}?";
+        EQ (S(str).template(values).s, 'Hello JP! How are you doing during the year of 2013?')
+						
         str = "Hello #{name}! How are you doing during the year of #{date-year}?"
         EQ (S(str).template(values, '#{', '}').s, 'Hello JP! How are you doing during the year of 2013?')
 


### PR DESCRIPTION
Previously, only {{value}} would work but {{ value}} / {{value }} / {{  value }} etc won't because of the included space. 

If anyone wants to add space for readability this will help.
