### PR TITLE
prevent  'to: wrong argument' output caused by shelljs

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -670,7 +670,8 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
       var name = names[i];
       var func = __nsp[name];
       try {
-        var type = typeof func.apply('teststring', []);
+        // #127: pass extra parameter to keep shelljs happy
+        var type = typeof func.apply('test', ['string']);
         retObj[name] = type;
       } catch (e) {}
     }


### PR DESCRIPTION
    `to` method in shelljs expects two arguments and throws an error if there is no second argument, so passing an extra string to keep it happy

This fixes #127 although I am not entirely sure if we should do it or not. 

@jprichardson thoughts ?