### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,7 @@
     "unescape"
   ],
   "author": "JP Richardson <jprichardson@gmail.com>",
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/