### PR TITLE
Added splitRight and splitLeft

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ Example:
 var stuff = "My name is JP\nJavaScript is my fav language\r\nWhat is your fav language?"
 var lines = S(stuff).lines()
 
-console.dir(lines) 
+console.dir(lines)
 /*
 [ 'My name is JP',
   'JavaScript is my fav language',
@@ -526,7 +526,7 @@ console.dir(lines)
 
 ### - pad(len, [char])
 
-Pads the string in the center with specified character. `char` may be a string or a number, defaults is a space. 
+Pads the string in the center with specified character. `char` may be a string or a number, defaults is a space.
 
 Example:
 
@@ -682,15 +682,43 @@ S('Crème brûlée').slugify().s // 'creme-brulee'
 ```
 
 
-### - startsWith(prefix)   ###
+### - splitLeft(sep, [maxSplit = -1, [limit]]) ###
+
+Returns an array of strings, split from the left at `sep`. Performs at most `maxSplit` splits, and slices the result into an array with at most `limit` elements.
+
+Example:
+
+```javascript
+S('We built this city').splitLeft(' '); // ['We', 'built', 'this', 'city'];
+S('We built this city').splitLeft(' ', 1); // ['We', 'built this city'];
+S('On Rock N Roll and other Stuff').splitLeft(' ', -1, 4); // ['On', 'Rock', 'N', 'Roll'];
+S('On Rock N Roll and other Stuff').splitLeft(' ', 5, -2); // ['and', 'other Stuff'];
+```
+
+
+### - splitRight(sep, [maxSplit = -1, [limit]]) ###
+
+Returns an array of strings, split from the left at `sep`. Performs at most `maxSplit` splits, and slices the result into an array with at most `limit` elements.
+
+Example:
+
+```javascript
+S('This is all very fun').splitRight(' '); // ['THis', 'built', 'this', 'city'];
+S('and I could do it forever').splitRight(' ', 1); // ['and I could do it', 'forever'];
+S('but nothing matters in the end.').splitRight(' ', -1, 2); // ['the', 'end.'];
+S('but nothing matters in the end.').splitRight(' ', 4, -2); // ['but nothing', 'matters'];
+```
+
+
+### - startsWith(prefix) ###
 
 Return true if the string starts with `prefix`.
 
 Example:
 
 ```javascript
-S("JP is a software engineer").startsWith("JP"); //true
-S('wants to change the world').startsWith("politicians"); //false
+S('JP is a software engineer').startsWith('JP'); //true
+S('wants to change the world').startsWith('politicians'); //false
 ```
 
 
@@ -997,7 +1025,7 @@ S('&lt;div&gt;hi&lt;/div&gt;').unescapeHTML().s; //<div>hi</div>
 
 ### - wrapHTML() ###
 
-wrapHTML helps to avoid concatenation of element with string. 
+wrapHTML helps to avoid concatenation of element with string.
 the string will be wrapped with HTML Element and their attributes.
 
 Example:
@@ -1101,8 +1129,9 @@ If you contribute to this library, just modify `string.js`, `string.test.js`, an
 - [*] [Nathan Friedly](https://github.com/nfriedly)
 - [*] [Alison Rowland](https://github.com/arowla)
 - [*] [Pascal Bihler](https://github.com/pbihler)
+- [*] [Daniel Diekmeier](https://github.com/danieldiekmeier)
 
- 
+
 
 Roadmap to v2.0
 ---------------
@@ -1135,6 +1164,3 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 [aboutjp]: http://about.me/jprichardson
 [twitter]: http://twitter.com/jprichardson
 [procbits]: http://procbits.com
-
-
-

--- a/lib/_splitLeft.js
+++ b/lib/_splitLeft.js
@@ -1,0 +1,27 @@
+function splitLeft(self, sep, maxSplit, limit) {
+
+  if (typeof maxSplit === 'undefined') {
+    var maxSplit = -1;
+  }
+
+  var splitResult = self.split(sep);
+  var splitPart1 = splitResult.slice(0, maxSplit);
+  var splitPart2 = splitResult.slice(maxSplit);
+
+  if (splitPart2.length === 0) {
+    splitResult = splitPart1;
+  } else {
+    splitResult = splitPart1.concat(splitPart2.join(sep));
+  }
+
+  if (typeof limit === 'undefined') {
+    return splitResult;
+  } else if (limit < 0) {
+    return splitResult.slice(limit);
+  } else {
+    return splitResult.slice(0, limit);
+  }
+
+}
+
+module.exports = splitLeft;

--- a/lib/_splitRight.js
+++ b/lib/_splitRight.js
@@ -1,0 +1,31 @@
+function splitRight(self, sep, maxSplit, limit) {
+
+  if (typeof maxSplit === 'undefined') {
+    var maxSplit = -1;
+  }
+  if (typeof limit === 'undefined') {
+    var limit = 0;
+  }
+
+  var splitResult = [self];
+
+  for (var i = self.length-1; i >= 0; i--) {
+
+    if (
+      splitResult[0].slice(i).indexOf(sep) === 0 &&
+      (splitResult.length <= maxSplit || maxSplit === -1)
+    ) {
+      splitResult.splice(1, 0, splitResult[0].slice(i+sep.length)); // insert
+      splitResult[0] = splitResult[0].slice(0, i)
+    }
+  }
+
+  if (limit >= 0) {
+    return splitResult.slice(-limit);
+  } else {
+    return splitResult.slice(0, -limit);
+  }
+
+}
+
+module.exports = splitRight;

--- a/lib/string.js
+++ b/lib/string.js
@@ -347,6 +347,14 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
       return new this.constructor(s);
     },
 
+    splitLeft: function(sep, maxSplit, limit) {
+      return require('./_splitLeft')(this.s, sep, maxSplit, limit)
+    },
+
+    splitRight: function(sep, maxSplit, limit) {
+      return require('./_splitRight')(this.s, sep, maxSplit, limit)
+    },
+
     strip: function() {
       var ss = this.s;
       for(var i= 0, n=arguments.length; i<n; i++) {
@@ -451,11 +459,11 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
     times: function(n) {
       return new this.constructor(new Array(n + 1).join(this.s));
     },
-    
+
     titleCase: function() {
       var s = this.s;
       if (s) {
-        s = s.replace(/(^[a-z]| [a-z]|-[a-z]|_[a-z])/g, 
+        s = s.replace(/(^[a-z]| [a-z]|-[a-z]|_[a-z])/g,
           function($1){
             return $1.toUpperCase();
           }

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -420,6 +420,112 @@
       })
     })
 
+    describe('- splitLeft(sep, [maxSplit, [limit]])', function() {
+      it('should return an array of strings, split from the left at sep, at most maxSplit splits, at most limit elements', function() {
+        // by a char
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitLeft('|'))
+        ARY_EQ (['a', 'b|c|d'], S('a|b|c|d').splitLeft('|', 1))
+        ARY_EQ (['a', 'b', 'c|d'], S('a|b|c|d').splitLeft('|', 2))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitLeft('|', 3))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitLeft('|', 4))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitLeft('|', 1000))
+        ARY_EQ (['a|b|c|d'], S('a|b|c|d').splitLeft('|', 0))
+        ARY_EQ (['a', '', 'b||c||d'], S('a||b||c||d').splitLeft('|', 2))
+        ARY_EQ (['', ' begincase'], S('| begincase').splitLeft('|'))
+        ARY_EQ (['endcase ', ''], S('endcase |').splitLeft('|'))
+        ARY_EQ (['', 'bothcase', ''], S('|bothcase|').splitLeft('|'))
+
+        ARY_EQ (['a', 'b', 'c\x00\x00d'], S('a\x00b\x00c\x00\x00d').splitLeft('\x00', 2))
+
+        // by string
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a//b//c//d').splitLeft('//'))
+        ARY_EQ (['a', 'b//c//d'], S('a//b//c//d').splitLeft('//', 1))
+        ARY_EQ (['a', 'b', 'c//d'], S('a//b//c//d').splitLeft('//', 2))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a//b//c//d').splitLeft('//', 3))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a//b//c//d').splitLeft('//', 4))
+        ARY_EQ (['a//b//c//d'], S('a//b//c//d').splitLeft('//', 0))
+        ARY_EQ (['a', '', 'b////c////d'], S('a////b////c////d').splitLeft('//', 2)) // overlap
+        ARY_EQ (['', ' begincase'], S('test begincase').splitLeft('test'))
+        ARY_EQ (['endcase ', ''], S('endcase test').splitLeft('test'))
+        ARY_EQ (['', ' bothcase ', ''], S('test bothcase test').splitLeft('test'))
+        ARY_EQ (['a', 'bc'], S('abbbc').splitLeft('bb'))
+        ARY_EQ (['', ''], S('aaa').splitLeft('aaa'))
+        ARY_EQ (['aaa'], S('aaa').splitLeft('aaa', 0))
+        ARY_EQ (['ab', 'ab'], S('abbaab').splitLeft('ba'))
+        ARY_EQ (['aaaa'], S('aaaa').splitLeft('aab'))
+        ARY_EQ ([''], S('').splitLeft('aaa'))
+        ARY_EQ (['aa'], S('aa').splitLeft('aaa'))
+        ARY_EQ (['A', 'bobb'], S('Abbobbbobb').splitLeft('bbobb'))
+        ARY_EQ (['', 'B', 'A'], S('bbobbBbbobbA').splitLeft('bbobb'))
+
+        // with limit
+        ARY_EQ (['a'], S('a|b|c|d').splitLeft('|', 3, 1))
+        ARY_EQ (['a', 'b', 'c'], S('a|b|c|d').splitLeft('|', 3, 3))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitLeft('|', 3, 4))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitLeft('|', 3, 5))
+
+        ARY_EQ (['d'], S('a|b|c|d').splitLeft('|', 3, -1))
+        ARY_EQ (['b', 'c|d'], S('a|b|c|d').splitLeft('|', 2, -2))
+        ARY_EQ (['b', 'c', 'd'], S('a|b|c|d').splitLeft('|', 3, -3))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitLeft('|', 3, -4))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitLeft('|', 3, -5))
+
+      })
+    })
+
+    describe('- splitRight(sep, [maxSplit, [limit]])', function() {
+      it('should return an array of strings, split from the right at sep, at most maxSplit splits, at most limit elements', function() {
+        // by a char
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitRight('|'))
+        ARY_EQ (['a|b|c', 'd'], S('a|b|c|d').splitRight('|', 1))
+        ARY_EQ (['a|b', 'c', 'd'], S('a|b|c|d').splitRight('|', 2))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitRight('|', 3))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitRight('|', 4))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitRight('|', 1000))
+        ARY_EQ (['a|b|c|d'], S('a|b|c|d').splitRight('|', 0))
+        ARY_EQ (['a||b||c', '', 'd'], S('a||b||c||d').splitRight('|', 2))
+        ARY_EQ (['', ' begincase'], S('| begincase').splitRight('|'))
+        ARY_EQ (['endcase ', ''], S('endcase |').splitRight('|'))
+        ARY_EQ (['', 'bothcase', ''], S('|bothcase|').splitRight('|'))
+
+        ARY_EQ (['a\x00\x00b', 'c', 'd'], S('a\x00\x00b\x00c\x00d').splitRight('\x00', 2))
+
+        // by string
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a//b//c//d').splitRight('//'))
+        ARY_EQ (['a//b//c', 'd'], S('a//b//c//d').splitRight('//', 1))
+        ARY_EQ (['a//b', 'c', 'd'], S('a//b//c//d').splitRight('//', 2))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a//b//c//d').splitRight('//', 3))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a//b//c//d').splitRight('//', 4))
+        ARY_EQ (['a//b//c//d'], S('a//b//c//d').splitRight('//', 0))
+        ARY_EQ (['a////b////c', '', 'd'], S('a////b////c////d').splitRight('//', 2)) // overlap
+        ARY_EQ (['', ' begincase'], S('test begincase').splitRight('test'))
+        ARY_EQ (['endcase ', ''], S('endcase test').splitRight('test'))
+        ARY_EQ (['', ' bothcase ', ''], S('test bothcase test').splitRight('test'))
+        ARY_EQ (['ab', 'c'], S('abbbc').splitRight('bb'))
+        ARY_EQ (['', ''], S('aaa').splitRight('aaa'))
+        ARY_EQ (['aaa'], S('aaa').splitRight('aaa', 0))
+        ARY_EQ (['ab', 'ab'], S('abbaab').splitRight('ba'))
+        ARY_EQ (['aaaa'], S('aaaa').splitRight('aab'))
+        ARY_EQ ([''], S('').splitRight('aaa'))
+        ARY_EQ (['aa'], S('aa').splitRight('aaa'))
+        ARY_EQ (['bbob', 'A'], S('bbobbbobbA').splitRight('bbobb'))
+        ARY_EQ (['', 'B', 'A'], S('bbobbBbbobbA').splitRight('bbobb'))
+
+        // with limit
+        ARY_EQ (['d'], S('a|b|c|d').splitRight('|', 3, 1))
+        ARY_EQ (['b', 'c', 'd'], S('a|b|c|d').splitRight('|', 3, 3))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitRight('|', 3, 4))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitRight('|', 3, 5))
+
+        ARY_EQ (['a'], S('a|b|c|d').splitRight('|', 3, -1))
+        ARY_EQ (['a|b', 'c'], S('a|b|c|d').splitRight('|', 2, -2))
+        ARY_EQ (['a', 'b', 'c'], S('a|b|c|d').splitRight('|', 3, -3))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitRight('|', 3, -4))
+        ARY_EQ (['a', 'b', 'c', 'd'], S('a|b|c|d').splitRight('|', 3, -5))
+
+      })
+    })
+
     describe('- strip([string1],[string2],...)', function() {
       it('should return the new string with all occurrences of [string1],[string2],... removed', function() {
         T (S('which ones will it take out one wonders').strip('on', 'er').s === 'which es will it take out e wds');
@@ -545,7 +651,7 @@
 
         var str = "{{greet }} {{ name}}! How are you doing during the year of {{  date-year }}?";
         EQ (S(str).template(values).s, 'Hello JP! How are you doing during the year of 2013?')
-						
+
         str = "Hello #{name}! How are you doing during the year of #{date-year}?"
         EQ (S(str).template(values, '#{', '}').s, 'Hello JP! How are you doing during the year of 2013?')
 
@@ -614,7 +720,7 @@
         T (S('*').times(3).s === '***');
       })
     })
- 
+
     describe('- titleCase()', function() {
       it('should upperCase all words in a camel cased string', function() {
         EQ (S('dataRate').titleCase().s, 'DataRate')


### PR DESCRIPTION
Like we discussed in #150, I added `splitLeft` and `splitRight` methods that work similar to Python's `split` and `rsplit`. I also ported the tests from Python and added some of my own, and I explained how they work in the README.

(I think my editor also accidentally cleaned up some stray spaces at the end of some lines)