### PR TITLE
Preserve all letters with accents while strip punctuation

### DIFF
--- a/dist/string.js
+++ b/dist/string.js
@@ -502,8 +502,7 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
     },
 
     stripPunctuation: function() {
-      //return new this.constructor(this.s.replace(/[\.,-\/#!$%\^&\*;:{}=\-_`~()]/g,""));
-      return new this.constructor(this.s.replace(/[^\w\s]|_/g, "").replace(/\s+/g, " "));
+      return new this.constructor(this.s.replace(/[^\w\s]|_/g, function(x) { return latin_map[x] ? x : ""; }).replace(/\s+/g, " "));
     },
 
     stripTags: function() { //from sugar.js

--- a/lib/string.js
+++ b/lib/string.js
@@ -425,8 +425,7 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
     },
 
     stripPunctuation: function() {
-      //return new this.constructor(this.s.replace(/[\.,-\/#!$%\^&\*;:{}=\-_`~()]/g,""));
-      return new this.constructor(this.s.replace(/[^\w\s]|_/g, "").replace(/\s+/g, " "));
+      return new this.constructor(this.s.replace(/[^\w\s]|_/g, function(x) { return latin_map[x] ? x : ""; }).replace(/\s+/g, " "));
     },
 
     stripTags: function() { //from sugar.js

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -632,7 +632,8 @@
 
     describe('- stripPunctuation()', function() {
       it('should strip all of the punctuation', function() {
-        T (S('My, st[ring] *full* of %punct)').stripPunctuation().s === 'My string full of punct')
+        T (S('My, st[ring] *full* of %punct)').stripPunctuation().s === 'My string full of punct');
+        T (S('Preserve   German  umlauts äöüÄÖÜß').stripPunctuation().s === 'Preserve German umlauts äöüÄÖÜß');
       })
     })
 


### PR DESCRIPTION
The regex replace function within the stripPunctuation method deletes all of the German umlauts.
Now the stripPunctuation function uses the latin_map to check every single letter before replacing it.
All German umlauts and other letters with accents will now preserved.