### PR TITLE
Introducing equalsIgnoreCase

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -129,6 +129,11 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
       var s = this.trim().s.replace(/[_\s]+/g, '-').replace(/([A-Z])/g, '-$1').replace(/-+/g, '-').toLowerCase();
       return new this.constructor(s);
     },
+    
+    equalsIgnoreCase: function(prefix) {
+      var s = this.s;
+      return s.toLowerCase() == prefix.toLowerCase()
+    },
 
     latinise: function() {
       var s = this.replace(/[^A-Za-z0-9\[\] ]/g, function(x) { return latin_map[x] || x; });

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -120,6 +120,18 @@
         EQ (S('funfunfun').count("fun"), 3)
       })
     })
+    
+    describe('- equalsIgnoreCase()', function() {
+      it('should be equal', function() {
+        T (S('jon').equalsIgnoreCase('Jon'));
+        T (S('Jon').equalsIgnoreCase('jon'));
+        T (S('jon').equalsIgnoreCase('jon'));
+        T (S('Jon').equalsIgnoreCase('Jon'));
+      })
+      it('should not be equal', function() {
+        F (S('John').equalsIgnoreCase('Jon'));
+      })
+    })
 
     describe('- dasherize()', function() {
       it('should convert a camel cased string into a string delimited by dashes', function() {


### PR DESCRIPTION
@jprichardson 
Pull request introducing equalsIgnoreCase function, I've been using String and I really missed this function.

usage:

S('StringJS').equalsIgnoreCase('stringjs')