### PR TITLE
Added hashCode method to implement Java-style string.hashCode()

### DIFF
--- a/dist/string.js
+++ b/dist/string.js
@@ -13,6 +13,23 @@ function count(self, substr) {
 
 module.exports = count
 },{}],2:[function(_dereq_,module,exports){
+function hashCode(self) {
+  if (self === null || self === undefined)
+    return 0
+
+  var hashCode = 0
+
+  for (var i = 0; i < self.length; i++) {
+    // Discard anything higher than 32-bits
+    hashCode = (31 * hashCode + self.charCodeAt(i)) & 0xFFFFFFFF
+  }
+
+  return hashCode
+}
+
+module.exports = hashCode
+
+},{}],3:[function(_dereq_,module,exports){
 function splitLeft(self, sep, maxSplit, limit) {
 
   if (typeof maxSplit === 'undefined') {
@@ -41,7 +58,7 @@ function splitLeft(self, sep, maxSplit, limit) {
 
 module.exports = splitLeft;
 
-},{}],3:[function(_dereq_,module,exports){
+},{}],4:[function(_dereq_,module,exports){
 function splitRight(self, sep, maxSplit, limit) {
 
   if (typeof maxSplit === 'undefined') {
@@ -74,7 +91,7 @@ function splitRight(self, sep, maxSplit, limit) {
 
 module.exports = splitRight;
 
-},{}],4:[function(_dereq_,module,exports){
+},{}],5:[function(_dereq_,module,exports){
 /*
 string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
 */
@@ -267,6 +284,11 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
       } else {
         return new this.constructor(s + suffix);
       }
+    },
+
+    // Generates a numeric hash code using the Java algorithm
+    hashCode: function() {
+      return _dereq_('./_hashCode')(this.s)
     },
 
     humanize: function() { //modified from underscore.string
@@ -1179,6 +1201,6 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
 
 }).call(this);
 
-},{"./_count":1,"./_splitLeft":2,"./_splitRight":3}]},{},[4])
-(4)
+},{"./_count":1,"./_hashCode":2,"./_splitLeft":3,"./_splitRight":4}]},{},[5])
+(5)
 });

--- a/lib/_hashCode.js
+++ b/lib/_hashCode.js
@@ -1,0 +1,15 @@
+function hashCode(self) {
+  if (self === null || self === undefined)
+    return 0
+
+  var hashCode = 0
+
+  for (var i = 0; i < self.length; i++) {
+    // Discard anything higher than 32-bits
+    hashCode = (31 * hashCode + self.charCodeAt(i)) & 0xFFFFFFFF
+  }
+
+  return hashCode
+}
+
+module.exports = hashCode

--- a/lib/string.js
+++ b/lib/string.js
@@ -192,6 +192,11 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
       }
     },
 
+    // Generates a numeric hash code using the Java algorithm
+    hashCode: function() {
+      return require('./_hashCode')(this.s)
+    },
+
     humanize: function() { //modified from underscore.string
       if (this.s === null || this.s === undefined)
         return new this.constructor('')

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -185,6 +185,17 @@
       })
     });
 
+    describe('- hashCode()', function() {
+      it('should return a proper Java hash code value for the string', function() {
+        EQ (S('').hashCode(), 0)
+        EQ (S('test').hashCode(), 3556498)
+        EQ (S('Hello World!').hashCode(), -969099747)
+        EQ (S('The quick brown fox jumps over the lazy dog.').hashCode(), -1712403141)
+        EQ (S('f5a5a608').hashCode(), 0)
+        EQ (S('string.js').hashCode(), -189328314)
+      })
+    })
+
     describe('- humanize()', function() {
       it('should humanize the string', function() {
         EQ (S('the_humanize_string_method').humanize().s, 'The humanize string method')


### PR DESCRIPTION
This implements the `hashCode()` behavior from Java's `String.hashCode()` method. It generates identical hash code values.

Also includes unit tests to verify this behavior.
