### PR TITLE
Added toSortOrder method for parsing sort order formats (ascending/descending)

### DIFF
--- a/dist/string.js
+++ b/dist/string.js
@@ -570,6 +570,21 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
       return /^\s*-?0x/i.test(this.s) ? parseInt(this.s, 16) : parseInt(this.s, 10)
     },
 
+    // Parses the string as a sort order
+    // Ascending can be: asc/ascending/1
+    // Descending can be: dsc/desc/descending/-1
+    toSortOrder: function(defaultOrder) {
+      defaultOrder = defaultOrder || 'ascending'
+
+      if (/^(asc|ascending|1)$/i.test(this.s))
+        return 'ascending'
+
+      if (/^(dsc|desc|descending|-1)$/i.test(this.s))
+        return 'descending'
+
+      return defaultOrder
+    },
+
     trim: function() {
       var s;
       if (typeof __nsp.trim === 'undefined')

--- a/lib/string.js
+++ b/lib/string.js
@@ -493,6 +493,21 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
       return /^\s*-?0x/i.test(this.s) ? parseInt(this.s, 16) : parseInt(this.s, 10)
     },
 
+    // Parses the string as a sort order
+    // Ascending can be: asc/ascending/1
+    // Descending can be: dsc/desc/descending/-1
+    toSortOrder: function(defaultOrder) {
+      defaultOrder = defaultOrder || 'ascending'
+
+      if (/^(asc|ascending|1)$/i.test(this.s))
+        return 'ascending'
+
+      if (/^(dsc|desc|descending|-1)$/i.test(this.s))
+        return 'descending'
+
+      return defaultOrder
+    },
+
     trim: function() {
       var s;
       if (typeof __nsp.trim === 'undefined')

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -810,6 +810,22 @@
       })
     })
 
+    describe('- toSortOrder(defaultOrder)', function() {
+      it('should return the parsed sort order (or the default value)', function() {
+        EQ (S('asc').toSortOrder(), 'ascending')
+        EQ (S('ascending').toSortOrder(), 'ascending')
+        EQ (S('1').toSortOrder(), 'ascending')
+        EQ (S(1).toSortOrder(), 'ascending')
+        EQ (S('dsc').toSortOrder(), 'descending')
+        EQ (S('desc').toSortOrder(), 'descending')
+        EQ (S('descending').toSortOrder(), 'descending')
+        EQ (S('-1').toSortOrder(), 'descending')
+        EQ (S(-1).toSortOrder(), 'descending')
+        EQ (S('not_valid').toSortOrder('ascending'), 'ascending')
+        EQ (S('also_invalid').toSortOrder('descending'), 'descending')
+      })
+    })
+
     describe('- toString()', function() {
       it('should return the native string', function() {
         T (S('hi').toString() === 'hi');


### PR DESCRIPTION
The `toSortOrder()` method parses a variety of sort order formats to get a common string value.

Ascending will match on `asc`, `ascending`, or `1`.

Descending will match on `dsc`, `desc`, `descending`, and `-1`.

The return value will be either `ascending`, `descending` (based on patterns) or the default fallback value.

The default fallback value can be provided, and is `ascending` if unspecified.
