### PR TITLE
Fix issue #192 (escapeHtml accepting null values)

### DIFF
--- a/dist/string.js
+++ b/dist/string.js
@@ -248,7 +248,12 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
     },
 
     escapeHTML: function() { //from underscore.string
-      return new this.constructor(this.s.replace(/[&<>"']/g, function(m){ return '&' + reversedEscapeChars[m] + ';'; }));
+      var s = this.s
+      if (s === null) {
+        return new this.constructor(s)
+      }
+      var escapedString = s.replace(/[&<>"']/g, function(m){ return '&' + reversedEscapeChars[m] + ';'; })
+      return new this.constructor(escapedString);
     },
 
     ensureLeft: function(prefix) {
@@ -692,7 +697,11 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
     },
 
     unescapeHTML: function() { //from underscore.string
-      return new this.constructor(this.s.replace(/\&([^;]+);/g, function(entity, entityCode){
+      var s = this.s
+      if (s === null) {
+        return new this.constructor(s)
+      }
+      var unescapedString = s.replace(/\&([^;]+);/g, function(entity, entityCode){
         var match;
 
         if (entityCode in escapeChars) {
@@ -704,7 +713,8 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
         } else {
           return entity;
         }
-      }));
+      })
+      return new this.constructor(unescapedString);
     },
 
     valueOf: function() {

--- a/lib/string.js
+++ b/lib/string.js
@@ -171,7 +171,12 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
     },
 
     escapeHTML: function() { //from underscore.string
-      return new this.constructor(this.s.replace(/[&<>"']/g, function(m){ return '&' + reversedEscapeChars[m] + ';'; }));
+      var s = this.s
+      if (s === null) {
+        return new this.constructor(s)
+      }
+      var escapedString = s.replace(/[&<>"']/g, function(m){ return '&' + reversedEscapeChars[m] + ';'; })
+      return new this.constructor(escapedString);
     },
 
     ensureLeft: function(prefix) {
@@ -615,7 +620,11 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
     },
 
     unescapeHTML: function() { //from underscore.string
-      return new this.constructor(this.s.replace(/\&([^;]+);/g, function(entity, entityCode){
+      var s = this.s
+      if (s === null) {
+        return new this.constructor(s)
+      }
+      var unescapedString = s.replace(/\&([^;]+);/g, function(entity, entityCode){
         var match;
 
         if (entityCode in escapeChars) {
@@ -627,7 +636,8 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
         } else {
           return entity;
         }
-      }));
+      })
+      return new this.constructor(unescapedString);
     },
 
     valueOf: function() {

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -170,6 +170,9 @@
     })
 
     describe('- escapeHTML()', function() {
+      it('should return null for a null value', function() {
+        EQ (S(null).escapeHTML().s, null)
+      })
       it('should escape the html', function() {
         T (S('<div>Blah & "blah" & \'blah\'</div>').escapeHTML().s ===
              '&lt;div&gt;Blah &amp; &quot;blah&quot; &amp; &apos;blah&apos;&lt;/div&gt;');
@@ -865,7 +868,10 @@
       })
     })
 
-    describe('- unescapeHTML', function() {
+    describe('- unescapeHTML()', function() {
+      it('should return null for a null value', function() {
+        EQ (S(null).unescapeHTML().s, null)
+      })
       it('should unescape the HTML', function() {
         T (S('&lt;div&gt;Blah &amp; &quot;blah&quot; &amp; &apos;blah&apos;&lt;/div&gt;').unescapeHTML().s ===
              '<div>Blah & "blah" & \'blah\'</div>');


### PR DESCRIPTION
The `escapeHtml()` and `unescapeHtml()` methods now return `null` when the string value itself is `null`.

Fixes issue #192 
