### PR TITLE
String: Updated mochify version in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - 8
+  - 7
   - 6
-  - 5
-  - 4
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
-  - iojs
+  - 6
+  - 5
+  - 4
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-uglify": "1.1.0",
     "istanbul": "*",
     "mocha": "*",
-    "mochify": "^2.9.0",
+    "mochify": "^5.8.1",
     "uglify-js": "1.3.x"
   },
   "main": "lib/string",


### PR DESCRIPTION
PhantomJS is an unmaintained project, removed the optional dependency of phantomJS from mochify to use headlesschrome.
Updated node version in travis.yml because earlier version used were very old.

Signed-off-by: ossdev07 <ossdev@puresoftware.com>