### PR TITLE
Remove IDE setting from npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.idea
 bower.json
 component.json
 .documentup.json


### PR DESCRIPTION
The `.idea` folder is also published on npm (`v3.3.3`), this PR prevents this from happening again.