### PR TITLE
Correct minor typo

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -76,7 +76,7 @@ string.js - Copyright (C) 2012-2014, JP Richardson <jprichardson@gmail.com>
 
     //# modified slightly from https://github.com/epeli/underscore.string
     camelize: function() {
-      var s = this.trim().s.replace(/(\-|_|\s)+(.)?/g, function(mathc, sep, c) {
+      var s = this.trim().s.replace(/(\-|_|\s)+(.)?/g, function(match, sep, c) {
         return (c ? c.toUpperCase() : '');
       });
       return new this.constructor(s);


### PR DESCRIPTION
Replace "mathc" argument with "match" in camelize's replacer function